### PR TITLE
fix bug in RelativePanel

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Panel/RelativePanel.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Panel/RelativePanel.cs
@@ -498,7 +498,7 @@ namespace HandyControl.Controls
                     }
                     else
                     {
-                        childPos.Y = (_arrangeSize.Height + node.AlignLeftWithNode.Position.Y - childSize.Height) / 2;
+                        childPos.Y = (_arrangeSize.Height + node.AlignTopWithNode.Position.Y - childSize.Height) / 2;
                     }
                 }
 


### PR DESCRIPTION
seems to be a copy and paste issue, null check is for 1 variable and then it operates on a different property.

Another issue I noticed, which I tried to fix and fail is:

put panel into vertical alignment = top, horizontal alignment = left...

then have 2 Rectangles in the panel, and the second... alignbottom with panel = true... the panel will fill the area.

In UWP this doesnt happen.

I think the measure pass needs to create the graph and measure the graph in this case... any pointers on how to fix this?

