### PR TITLE
Slightly improve getting OSVersion

### DIFF
--- a/src/Shared/HandyControl_Shared/HandyControls/Tools/Helper/OSVersionHelper.cs
+++ b/src/Shared/HandyControl_Shared/HandyControls/Tools/Helper/OSVersionHelper.cs
@@ -186,6 +186,9 @@ namespace HandyControl.Tools
         public static Version GetOSVersion()
         {
             var osv = new InteropValues.RTL_OSVERSIONINFOEX();
+#if (NET40 || NET45)
+            osv.dwOSVersionInfoSize = (uint) Marshal.SizeOf(osv);
+#endif
             InteropMethods.RtlGetVersion(out osv);
             return new Version((int) osv.dwMajorVersion, (int) osv.dwMinorVersion, (int) osv.dwBuildNumber, (int) osv.dwRevision);
         }

--- a/src/Shared/HandyControl_Shared/HandyControls/Tools/Helper/OSVersionHelper.cs
+++ b/src/Shared/HandyControl_Shared/HandyControls/Tools/Helper/OSVersionHelper.cs
@@ -186,7 +186,6 @@ namespace HandyControl.Tools
         public static Version GetOSVersion()
         {
             var osv = new InteropValues.RTL_OSVERSIONINFOEX();
-            osv.dwOSVersionInfoSize = (uint) Marshal.SizeOf(osv);
             InteropMethods.RtlGetVersion(out osv);
             return new Version((int) osv.dwMajorVersion, (int) osv.dwMinorVersion, (int) osv.dwBuildNumber, (int) osv.dwRevision);
         }

--- a/src/Shared/HandyControl_Shared/Tools/Interop/InteropValues.cs
+++ b/src/Shared/HandyControl_Shared/Tools/Interop/InteropValues.cs
@@ -1078,7 +1078,7 @@ namespace HandyControl.Tools.Interop
         [StructLayout(LayoutKind.Sequential)]
         public struct RTL_OSVERSIONINFOEX
         {
-            public uint dwOSVersionInfoSize;
+            public readonly uint  dwOSVersionInfoSize { get; init; } = (uint)Marshal.SizeOf<RTL_OSVERSIONINFOEX>();
             public uint dwMajorVersion;
             public uint dwMinorVersion;
             public uint dwBuildNumber;

--- a/src/Shared/HandyControl_Shared/Tools/Interop/InteropValues.cs
+++ b/src/Shared/HandyControl_Shared/Tools/Interop/InteropValues.cs
@@ -1078,7 +1078,12 @@ namespace HandyControl.Tools.Interop
         [StructLayout(LayoutKind.Sequential)]
         public struct RTL_OSVERSIONINFOEX
         {
-            public readonly uint  dwOSVersionInfoSize { get; init; } = (uint)Marshal.SizeOf<RTL_OSVERSIONINFOEX>();
+#if (NET40 || NET45)
+
+            public uint dwOSVersionInfoSize;
+#else
+            public readonly uint dwOSVersionInfoSize { get; init; } = (uint)Marshal.SizeOf<RTL_OSVERSIONINFOEX>();
+#endif
             public uint dwMajorVersion;
             public uint dwMinorVersion;
             public uint dwBuildNumber;


### PR DESCRIPTION
`Marshal.SizeOf<>` is faster than `Marshal.SizeOf()`. Also get rid of the extra line which sets `dwOSVersionInfoSize` as  we can do this within the struct.