### PR TITLE
Use WindowCaptionHeight for NonClientAreaHeight default value

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Window/Window.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Window/Window.cs
@@ -202,7 +202,7 @@ namespace HandyControl.Controls
 
         public static readonly DependencyProperty NonClientAreaHeightProperty = DependencyProperty.Register(
             "NonClientAreaHeight", typeof(double), typeof(Window),
-            new PropertyMetadata(22.0));
+            new PropertyMetadata(SystemParameters.WindowCaptionHeight));
 
         public double NonClientAreaHeight
         {


### PR DESCRIPTION
SystemParameters.WindowCaptionHeight maybe better.