### PR TITLE
resolve GetWindowPlacement PInvoke error

### DIFF
--- a/src/Shared/HandyControl_Shared/Tools/Interop/InteropValues.cs
+++ b/src/Shared/HandyControl_Shared/Tools/Interop/InteropValues.cs
@@ -464,7 +464,7 @@ public class InteropValues
             get
             {
                 WINDOWPLACEMENT result = new WINDOWPLACEMENT();
-                result.length = Marshal.SizeOf(result);
+                result.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
                 return result;
             }
         }


### PR DESCRIPTION
#183  HandyControl!HandyControl.Tools.Interop.InteropMethods::GetWindowPlacement”的调用导致堆栈不对称