### PR TITLE
编译目标为x86,netframework4.8的情况下报错

### DIFF
--- a/src/Shared/HandyControl_Shared/Tools/Helper/FullScreenHelper.cs
+++ b/src/Shared/HandyControl_Shared/Tools/Helper/FullScreenHelper.cs
@@ -26,7 +26,7 @@ public static class FullScreenHelper
     /// </summary>
     private static readonly DependencyProperty BeforeFullScreenWindowStyleProperty =
         DependencyProperty.RegisterAttached("BeforeFullScreenWindowStyle",
-            typeof(InteropValues.WindowStyles?), typeof(FullScreenHelper));
+            typeof(InteropValues.WindowStyles), typeof(FullScreenHelper));
 
     /// <summary>
     /// 开始进入全屏模式

--- a/src/Shared/HandyControl_Shared/Tools/Interop/InteropMethods.cs
+++ b/src/Shared/HandyControl_Shared/Tools/Interop/InteropMethods.cs
@@ -310,7 +310,7 @@ public class InteropMethods
 
     public static InteropValues.WINDOWPLACEMENT GetWindowPlacement(IntPtr hwnd)
     {
-        InteropValues.WINDOWPLACEMENT wINDOWPLACEMENT = InteropValues.WINDOWPLACEMENT.Default;
+        InteropValues.WINDOWPLACEMENT wINDOWPLACEMENT =new InteropValues.WINDOWPLACEMENT();
         if (GetWindowPlacement(hwnd, wINDOWPLACEMENT))
         {
             return wINDOWPLACEMENT;

--- a/src/Shared/HandyControl_Shared/Tools/Interop/InteropValues.cs
+++ b/src/Shared/HandyControl_Shared/Tools/Interop/InteropValues.cs
@@ -447,27 +447,27 @@ public class InteropValues
     }
 
     [StructLayout(LayoutKind.Sequential)]
-    public struct WINDOWPLACEMENT
+    public class WINDOWPLACEMENT
     {
-        public int length;
+        public int length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
         public int flags;
         public SW showCmd;
         public POINT ptMinPosition;
         public POINT ptMaxPosition;
         public RECT rcNormalPosition;
 
-        /// <summary>
-        /// Gets the default (empty) value.
-        /// </summary>
-        public static WINDOWPLACEMENT Default
-        {
-            get
-            {
-                WINDOWPLACEMENT result = new WINDOWPLACEMENT();
-                result.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
-                return result;
-            }
-        }
+        ///// <summary>
+        ///// Gets the default (empty) value.
+        ///// </summary>
+        //public static WINDOWPLACEMENT Default
+        //{
+        //    get
+        //    {
+        //        WINDOWPLACEMENT result = new WINDOWPLACEMENT();
+        //        result.length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
+        //        return result;
+        //    }
+        //}
     }
 
     [Serializable]


### PR DESCRIPTION
托管调试助手 "PInvokeStackImbalance":“对 PInvoke 函数“HandyControl!HandyControl.Tools.Interop.InteropMethods::GetWindowPlacement”的调用导致堆栈不对称。原因可能是托管的 PInvoke 签名与非托管的目标签名不匹配。请检查 PInvoke 签名的调用约定和参数与非托管的目标签名是否匹配。”

之前改了正常后，现在系统升级到window11后又不正常了，现在恢复到3.8.8前的代码，win11测试正常。