### PR TITLE
fix(ProgressBar): Replace StaticResource with DynamicResource to reso…

### DIFF
--- a/src/Shared/HandyControl_Shared/Themes/Styles/Base/ProgressBarBaseStyle.xaml
+++ b/src/Shared/HandyControl_Shared/Themes/Styles/Base/ProgressBarBaseStyle.xaml
@@ -53,7 +53,7 @@
                                             <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="{DynamicResource TextIconBrush}" Text="{Binding Path=(hc:VisualElement.Text),RelativeSource={RelativeSource TemplatedParent}}"/>
                                         </Border>
                                     </Border>
-                                    <Rectangle x:Name="PART_GlowRect" Fill="{StaticResource ProgressBarIndicatorAnimatedFill}" HorizontalAlignment="Left" Margin="-100,0,0,0" Width="100"/>
+                                    <Rectangle x:Name="PART_GlowRect" Fill="{DynamicResource ProgressBarIndicatorAnimatedFill}" HorizontalAlignment="Left" Margin="-100,0,0,0" Width="100"/>
                                     <Rectangle x:Name="Animation" Visibility="Collapsed" Fill="{TemplateBinding Foreground}" RenderTransformOrigin="0.5,0.5">
                                         <Rectangle.RenderTransform>
                                             <TransformGroup>


### PR DESCRIPTION
**Problem:**
When a ProgressBar using the `ProgressBarBaseStyleAlt` style is instantiated on a different thread, the window crashes with:

```
System.InvalidOperationException: Cannot use a DependencyObject that belongs to a different thread than its parent Freezable.
The root cause is the StaticResource ProgressBarIndicatorAnimatedFill reference in the PART_GlowRect Rectangle. Since StaticResource is thread-affine, reusing it across threads violates WPF's threading model.
```

**Fix:**
Replace StaticResource with DynamicResource for ProgressBarIndicatorAnimatedFill:

```xml
<Rectangle x:Name="PART_GlowRect" 
           Fill="{DynamicResource ProgressBarIndicatorAnimatedFill}" 
           HorizontalAlignment="Left" 
           Margin="-100,0,0,0" 
           Width="100"/>
```